### PR TITLE
Add support for optional package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,33 @@
 # findlibs
 
-A Python package that search for shared libraries on various platforms.
+A Python package to search for shared libraries on various platforms.
 
+## Install
+
+```sh
+pip install findlibs
+```
+
+## Usage
 
 ```python
 import findlibs
 lib = findlibs.find("eccodes")
+
+# If package name is different than the library name
+lib = findlibs.find("odccore", "odc")
+```
+
+## Development
+
+### Setup Environment
+
+```sh
+pip install -r requirements.txt
+```
+
+### Run Tests
+
+```sh
+python -m pytest
 ```

--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -15,39 +15,58 @@ import sys
 __version__ = "0.0.2"
 
 
-
 EXTENSIONS = {
     "darwin": ".dylib",
     "win32": ".dll",
 }
 
 
-def find(name):
-    """Returns the path to the selected library, or None if not found."""
+def find(libname, pkgname=None):
+    """
+    Returns the path to the selected library, or None if not found.
+
+    Parameters:
+        libname(str): Name of the library, excluding "lib" prefix
+        pkgname(str, optional): Name of the package, if different than name of
+            the library.
+
+    Returns:
+        str: Path to the library
+    """
 
     extension = EXTENSIONS.get(sys.platform, ".so")
+    pkgname = pkgname or libname
 
     for what in ("HOME", "DIR"):
-        LIB_HOME = "{}_{}".format(name.upper(), what)
-        if LIB_HOME in os.environ:
-            home = os.environ[LIB_HOME]
-            fullname = os.path.join(home, "lib", "lib{}{}".format(name, extension))
-            if os.path.exists(fullname):
-                return fullname
+        envs = [
+            "{}_{}".format(pkgname.upper(), what),
+            "{}_{}".format(pkgname.lower(), what),
+        ]
+        for env in envs:
+            if env in os.environ:
+                home = os.environ[env]
+                for lib in ("lib", "lib64"):
+                    fullname = os.path.join(
+                        home, lib, "lib{}{}".format(libname, extension)
+                    )
+                    if os.path.exists(fullname):
+                        return fullname
 
     for path in (
         "LD_LIBRARY_PATH",
         "DYLD_LIBRARY_PATH",
     ):
         for home in os.environ.get(path, "").split(":"):
-            fullname = os.path.join(home, "lib{}{}".format(name, extension))
+            fullname = os.path.join(home, "lib{}{}".format(libname, extension))
             if os.path.exists(fullname):
                 return fullname
 
     for root in ("/", "/usr/", "/usr/local/", "/opt/"):
         for lib in ("lib", "lib64"):
-            fullname = os.path.join(home, "{}{}/lib{}{}".format(root, lib, name, extension))
+            fullname = os.path.join(
+                root, lib, "lib{}{}".format(libname, extension)
+            )
             if os.path.exists(fullname):
                 return fullname
 
-    return ctypes.util.find_library(name)
+    return ctypes.util.find_library(libname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=6.2.4
+pytest-mock>=3.6.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ assert version
 setuptools.setup(
     name="findlibs",
     version=version,
-    description="A packages to search for shared libraries on various platforms",
+    description="A package to search for shared libraries on various "
+                "platforms",
     long_description=read("README.md"),
     author="European Centre for Medium-Range Weather Forecasts (ECMWF)",
     author_email="software.support@ecmwf.int",
@@ -41,6 +42,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=[],
+    tests_require=[
+        "pytest",
+        "pytest-mock",
+    ],
     zip_safe=True,
     keywords="tool",
     classifiers=[
@@ -51,6 +56,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Operating System :: OS Independent",

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -1,0 +1,171 @@
+import os
+
+import pytest
+
+import findlibs
+
+EXTENSIONS = {
+    "linux": ".so",
+    "darwin": ".dylib",
+    "win32": ".dll",
+}
+
+
+@pytest.mark.parametrize("platform", dict.keys(EXTENSIONS))
+@pytest.mark.parametrize("env", ("HOME", "DIR"))
+@pytest.mark.parametrize("lib", ("lib", "lib64"))
+@pytest.mark.parametrize("found", (True, False))
+def test_find_envs(mocker, platform, env, lib, found):
+    """
+    Checks for correct return value when relying on environment variables.
+
+    Following environment variables will be checked:
+    - <libname>_HOME or <LIBNAME>_HOME
+    - <libname>_DIR or <LIBNAME>_DIR
+    """
+
+    libname = "somename"
+    libpath = "/some/path"
+
+    def mock_path_exists(path):
+        """Mocks skipping missing lib paths on different parameters"""
+        if lib not in path:
+            return False
+        return found
+
+    for libname_cased in (libname.upper(), libname.lower()):
+        mocker.patch("sys.platform", platform)
+        mocker.patch(
+            "os.environ", {"{}_{}".format(libname_cased, env): libpath}
+        )
+        mocker.patch("os.path.exists", mock_path_exists)
+
+        result = findlibs.find(libname)
+        if found:
+            assert result == os.path.join(
+                libpath, lib, "lib{}{}".format(libname, EXTENSIONS[platform])
+            )
+        else:
+            assert result is None
+
+
+@pytest.mark.parametrize("platform", dict.keys(EXTENSIONS))
+@pytest.mark.parametrize("env", ("HOME", "DIR"))
+@pytest.mark.parametrize("lib", ("lib", "lib64"))
+@pytest.mark.parametrize("found", (True, False))
+def test_find_envs_pkgname(mocker, platform, env, lib, found):
+    """
+    Checks for correct return value when relying on environment variables,
+    with an optional package name.
+
+    If a package name is passed, it will be used for checking following
+    environment variables:
+    - <pkgname>_HOME or <PKGNAME>_HOME
+    - <pkgname>_DIR or <PKGNAME>_DIR
+    """
+
+    libname = "somename"
+    pkgname = "differentname"
+    libpath = "/some/path"
+
+    def mock_path_exists(path):
+        """Mocks skipping missing lib paths on different parameters"""
+        if lib not in path:
+            return False
+        return found
+
+    for pkgname_cased in (pkgname.upper(), pkgname.lower()):
+        mocker.patch("sys.platform", platform)
+        mocker.patch(
+            "os.environ", {"{}_{}".format(pkgname_cased, env): libpath}
+        )
+        mocker.patch("os.path.exists", mock_path_exists)
+
+        result = findlibs.find(libname, pkgname)
+        if found:
+            assert result == os.path.join(
+                libpath, lib, "lib{}{}".format(libname, EXTENSIONS[platform])
+            )
+        else:
+            assert result is None
+
+
+@pytest.mark.parametrize("platform", dict.keys(EXTENSIONS))
+@pytest.mark.parametrize("env", ("LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"))
+@pytest.mark.parametrize("lib", ("lib", "lib64"))
+@pytest.mark.parametrize("found", (True, False))
+def test_find_ld_path(mocker, platform, env, lib, found):
+    """
+    Checks for correct return value when relying on LD paths.
+
+    Following environment variables will be checked:
+    - LD_LIBRARY_PATH
+    - DYLD_LIBRARY_PATH
+
+    If they contain multiple paths, they will be split on ":" and each
+    component will be considered (left to right).
+    """
+
+    libname = "somename"
+    ld_path = "/some/path/lib:/another/path/lib64"
+    ld_paths = {
+        "lib": ld_path.split(":")[0],
+        "lib64": ld_path.split(":")[1],
+    }
+
+    def mock_path_exists(path):
+        """Mocks skipping missing lib paths on different parameters"""
+        if path == "lib{}{}".format(libname, EXTENSIONS[platform]):
+            return False
+        if lib not in path:
+            return False
+        return found
+
+    mocker.patch("sys.platform", platform)
+    mocker.patch.dict("os.environ", {env: ld_path})
+    mocker.patch("os.path.exists", mock_path_exists)
+
+    result = findlibs.find(libname)
+    if found:
+        assert result == os.path.join(
+            ld_paths[lib], "lib{}{}".format(libname, EXTENSIONS[platform])
+        )
+    else:
+        assert result is None
+
+
+@pytest.mark.parametrize("platform", dict.keys(EXTENSIONS))
+@pytest.mark.parametrize("root", ("/", "/usr/", "/usr/local/", "/opt/"))
+@pytest.mark.parametrize("lib", ("lib", "lib64"))
+@pytest.mark.parametrize("found", (True, False))
+def test_find_common_path(mocker, platform, root, lib, found):
+    """
+    Checks for correct return value when relying on common paths.
+
+    Following system paths will be checked:
+    - /
+    - /usr/
+    - /usr/local/
+    - /opt/
+    """
+
+    libname = "somename"
+
+    def mock_path_exists(path):
+        """Mocks skipping missing lib paths on different parameters"""
+        if root not in path:
+            return False
+        if lib not in path:
+            return False
+        return found
+
+    mocker.patch("sys.platform", platform)
+    mocker.patch("os.path.exists", mock_path_exists)
+
+    result = findlibs.find(libname)
+    if found:
+        assert result == os.path.join(
+            root, lib, "lib{}{}".format(libname, EXTENSIONS[platform])
+        )
+    else:
+        assert result is None

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,7 @@
+import subprocess
+import sys
+
+
+def test_setup():
+    """Performs some tests on the meta-data of a package"""
+    subprocess.check_call([sys.executable, "setup.py", "check"])


### PR DESCRIPTION
In case a package has a different name than the library, the path might never be found.

Case in point `odc` (in `pyodc` project):

* Library name: `odccore`
* Library filename: `libodccore.{so,dylib}`
* Supported environment variables: `ODC_DIR`, `odc_DIR`

By providing an optional package name as a second parameter to `find()`, we can check _expected_ environment variables. Additionally, support for both upper and lowercase variable names has been added and search extended to two architectures (`lib` and `lib64`).

Test suite based on `pytest` and `pytest-mock` was also added, since the module lacked any tests.

The README was suitably extended to document the new behaviour.q