### PR TITLE
Add compatibility for libraries installed via homebrew on M1 macs

### DIFF
--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -44,7 +44,7 @@ def find(name):
             if os.path.exists(fullname):
                 return fullname
 
-    for root in ("/", "/usr/", "/usr/local/", "/opt/"):
+    for root in ("/", "/usr/", "/usr/local/", "/opt/", "/opt/homebrew/"):
         for lib in ("lib", "lib64"):
             fullname = os.path.join(home, "{}{}/lib{}{}".format(root, lib, name, extension))
             if os.path.exists(fullname):


### PR DESCRIPTION
As of version 2.6.0 of the homebrew package manager, native
libraries on M1 macs are installed to /opt/homebrew/lib to
avoid comflict with intel compiled libraries installed into
/usr/local/lib (See release notes here:
https://brew.sh/2020/12/01/homebrew-2.6.0/ ).

This patch allows findlib to locate libraries installed in that
location. This allows, for example, this cfgrib package to find
the eccodes library when installed via `brew install eccodes` on
an M1 mac.