### PR TITLE
Add support for different package and library names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 A Python package that search for shared libraries on various platforms.
 
-
 ```python
 import findlibs
 lib = findlibs.find("eccodes")
+
+# If package name differs from library name use:
+lib = findlibs.find(lib_name="odccore", pkg_name="odc")
 ```


### PR DESCRIPTION
Adds support for cases where package and library names are not the same.
Adds support for both lower and upper case package names in environment variables.

The main reason for this PR is to be able to use `findlibs` in `pyodc` to locate `odc` library which has:
- package name: `odc`
- library name: `libodccore.so`

This is achieved by an optional `pkg_name` parameter.
