### PR TITLE
Add ~/local to list of global library install locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ lib = findlibs.find("eccodes")
 # If package name differs from library name use:
 lib = findlibs.find(lib_name="odccore", pkg_name="odc")
 ```
+
+## Testing
+
+```bash
+git clone https://github.com/ecmwf/findlibs
+cd findlibs
+pip install -e ".[test]"
+pytest
+```

--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -71,7 +71,7 @@ def find(lib_name, pkg_name=None):
             if os.path.exists(fullname):
                 return fullname
 
-    for root in ("/", "/usr/", "/usr/local/", "/opt/", "/opt/homebrew/", os.path.expanduser("~/local")):
+    for root in ("/", "/usr/", "/usr/local/", "/opt/", "/opt/homebrew/", os.path.expanduser("~/.local")):
         for lib in ("lib", "lib64"):
             fullname = os.path.join(root, lib, "lib{}{}".format(lib_name, extension))
             if os.path.exists(fullname):

--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -71,7 +71,7 @@ def find(lib_name, pkg_name=None):
             if os.path.exists(fullname):
                 return fullname
 
-    for root in ("/", "/usr/", "/usr/local/", "/opt/", "/opt/homebrew/"):
+    for root in ("/", "/usr/", "/usr/local/", "/opt/", "/opt/homebrew/", os.path.expanduser("~/local")):
         for lib in ("lib", "lib64"):
             fullname = os.path.join(root, lib, "lib{}{}".format(lib_name, extension))
             if os.path.exists(fullname):

--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -8,22 +8,6 @@
 # nor does it submit to any jurisdiction.
 #
 
-"""
-Use python config parser
-
-file locations: 
-~/.findlibs, ~/.config/findlibs/findlibs.conf
-if both, throw error
-
-config file: 
-[Paths]
-/path/to/foo
-/path/to/bar
-/path/to/baz
-
-if relative paths or files, throw error
-"""
-
 import ctypes.util
 import os
 import sys

--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -40,7 +40,6 @@ def _get_paths_from_config():
         config.read(locations[0])
     
     if "Paths" not in config: return []
-    print(config)
     # replace $HOME with ~, expand ~ to full path, 
     # resolve any relative paths to absolute paths
     paths = {Path(p.replace("$HOME", "~")).expanduser()
@@ -86,7 +85,6 @@ def find(lib_name, pkg_name=None):
     for root in roots:
         for lib in ("lib", "lib64"):
             fullname = os.path.join(root, lib, libname)
-            print(f"looking at {fullname}")
             if os.path.exists(fullname):
                 return fullname
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     url="https://github.com/ecmwf/findlibs",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["PyYAML"],
+    install_requires=[],
     extras_require={
         'test': ["pytest", "pyfakefs"]
     },

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,10 @@ setuptools.setup(
     url="https://github.com/ecmwf/findlibs",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=[],
+    install_requires=["PyYAML"],
+    extras_require={
+        'test': ["pytest", "pyfakefs"]
+    },
     zip_safe=True,
     keywords="tool",
     classifiers=[

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,33 @@
+import pytest
+import pyfakefs # registers a fixture called "fs" with pytest
+import sys
+import os
+import findlibs
+from pathlib import Path
+
+pkg_name = "foobar"
+extension = findlibs.EXTENSIONS.get(sys.platform, ".so")
+libname = f"lib{pkg_name}{extension}"
+
+conda_prefix = '/test/conda/prefix'
+os.environ["CONDA_PREFIX"] = conda_prefix
+env_variable_location = os.environ[f"{pkg_name}_HOME"] = "/test/environment/variable"
+ld_library_location = os.environ["LD_LIBRARY_PATH"] = "/test/ld_library/"
+
+
+# A list of test locations in order of precedence
+# test_find checks that if a file is placed in any of these locations then it is found
+test_locations = [
+    sys.prefix,
+    conda_prefix,
+    env_variable_location,
+    "/", "/usr/", "/usr/local/", "/opt/", "/opt/homebrew/", os.path.expanduser("~/.local")
+]
+
+@pytest.mark.parametrize("location", test_locations)
+def test_find(fs, location):
+    libpath = Path(location) / "lib" / libname
+    print(f"creating {libpath}")
+    fs.create_file(libpath)
+    assert findlibs.find(pkg_name) == str(libpath)
+    

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
 import pytest
 import pyfakefs # registers a fixture called "fs" with pytest
 import sys

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,0 +1,52 @@
+import pytest
+import pyfakefs # registers a fixture called "fs" with pytest
+import sys
+import findlibs
+from pathlib import Path
+
+extension = findlibs.EXTENSIONS.get(sys.platform, ".so")
+testlib_path = Path(f"/usr/lib/test{extension}")
+config_path = Path(f"~/.findlibs.yml").expanduser().resolve()
+
+def test_no_config_file(fs):
+    "Check that findlibs works with no config file"
+    fs.create_file(testlib_path)
+    assert findlibs.find("test") == str(testlib_path)
+
+def test_empty_config_file(fs):
+    "Check that it works with an empty config file"
+    fs.create_file(testlib_path)
+    fs.create_file(config_path)
+    assert config_path.exists()
+    assert findlibs.find("test") == str(testlib_path)
+
+def test_empty_search_paths(fs):
+    "Check that it works with an empty config file"
+    fs.create_file(testlib_path)
+    fs.create_file(config_path, contents = 
+"""
+additional_search_paths:
+""")
+
+    assert config_path.exists()
+    assert findlibs.find("test") == str(testlib_path)
+
+# Parametrised tests over
+# search_dir: a path you could put into .findlibs.yml
+# testlib_path: a concrete test path to check we can find tings in search_dir
+@pytest.mark.parametrize("search_dir,testlib_path", [
+                ("/test/usr", f"/test/usr/lib/libtest{extension}"), # absolute paths
+                ("/test/usr", f"/test/usr/lib64/libtest{extension}"), # lib64 aswell as lib
+                ("~/.local", Path(f"~/.local/lib/libtest{extension}").expanduser()), # ~ expansion
+                ("$HOME/.local", Path(f"~/.local/lib/libtest{extension}").expanduser()), # $HOME expansion
+])
+def test_config(fs, search_dir, testlib_path):
+
+    fs.create_file(testlib_path)
+    fs.create_file(config_path, contents = 
+f"""
+additional_search_paths:
+  - {search_dir}
+""")
+    assert findlibs.find("test") == str(testlib_path)
+    

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+# (C) Copyright 2020 ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
 import pytest
 import pyfakefs # registers a fixture called "fs" with pytest
 import sys

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -5,7 +5,7 @@ import findlibs
 from pathlib import Path
 
 extension = findlibs.EXTENSIONS.get(sys.platform, ".so")
-testlib_path = f"/usr/lib/test{extension}"
+testlib_path = f"/usr/lib/libtest{extension}"
 config_paths = [str(Path(p).expanduser()) for p in [f"~/.config/findlibs/findlibs.conf",
                 f"~/.findlibs"]]
 

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -5,16 +5,14 @@ import findlibs
 from pathlib import Path
 
 extension = findlibs.EXTENSIONS.get(sys.platform, ".so")
-testlib_path = Path(f"/usr/lib/test{extension}")
-config_path = Path(f"~/.config/findlibs/findlibs.conf").expanduser().resolve()
-
-config_paths = [Path(f"~/.config/findlibs/findlibs.conf").expanduser().resolve(),
-                Path(f"~/.findlibs").expanduser().resolve()]
+testlib_path = f"/usr/lib/test{extension}"
+config_paths = [str(Path(p).expanduser()) for p in [f"~/.config/findlibs/findlibs.conf",
+                f"~/.findlibs"]]
 
 def test_no_config_file(fs):
     "Check that findlibs works with no config file"
     fs.create_file(testlib_path)
-    assert findlibs.find("test") == str(testlib_path)
+    assert findlibs.find("test") == testlib_path
 
 def test_both_config_files(fs):
     "Check that it throws an error if two config files are present"
@@ -24,7 +22,7 @@ def test_both_config_files(fs):
 
 def test_relative_path(fs):
     "Check that it throws an error on relative paths"
-    fs.create_file(config_path, contents = 
+    fs.create_file(config_paths[0], contents = 
 """
 [Paths]
 relative/path
@@ -35,7 +33,7 @@ relative/path
 
 def test_file(fs):
     "Check that it throws an error when files are included"
-    fs.create_file(config_path, contents = 
+    fs.create_file(config_paths[0], contents = 
 """
 [Paths]
 /path/to/file.so
@@ -47,20 +45,17 @@ def test_file(fs):
 def test_empty_config_file(fs):
     "Check that it works with an empty config file"
     fs.create_file(testlib_path)
-    fs.create_file(config_path)
-    assert config_path.exists()
-    assert findlibs.find("test") == str(testlib_path)
+    fs.create_file(config_paths[0])
+    assert findlibs.find("test") == testlib_path
 
 def test_empty_search_paths(fs):
     "Check that it works with an empty config file"
     fs.create_file(testlib_path)
-    fs.create_file(config_path, contents = 
+    fs.create_file(config_paths[0], contents = 
 """
 [Paths]
 """)
-
-    assert config_path.exists()
-    assert findlibs.find("test") == str(testlib_path)
+    assert findlibs.find("test") == testlib_path
 
 # Parametrised tests over
 # search_dir: a path you could put into .findlibs.yml
@@ -74,7 +69,7 @@ def test_empty_search_paths(fs):
 def test_config(fs, search_dir, testlib_path):
 
     fs.create_file(testlib_path)
-    fs.create_file(config_path, contents = 
+    fs.create_file(config_paths[0], contents = 
 f"""
 [Paths]
 {search_dir}


### PR DESCRIPTION
On my Mac machine, if I follow the[ odc build instructions](https://github.com/ecmwf/odc/blob/master/README.md#:~:text=git%20clone%20https,bin/odc%20%2D%2Dversion) and run `make install` I find that `libodccore.dylib ` ends up  in `~/local/lib/libodccore.dylib` and `find("odccore", pkg_name="odc")` cannot find it.

Hence I suggest adding `os.path.expanduser("~/local")` to the list of search directories for globally installed files which would fix this with no user intervention. 

I had previously set an `odc_DIR` environment variable to get this to work but then realised it doesn't propagate nicely to jupyter, and hence I can't `import codc` there. 

The alternative fix might be to add a way for `make install` to install to "$CONDA_PREFIX/lib/libodccore.dylib" since that is the first place`find` looks and seems like a reasonable place for ODCs`make install` command to put its libraries.