### PR TITLE
Fix ctypes.util.find_library usage

### DIFF
--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -232,7 +232,8 @@ def _find_in_ctypes_util(lib_name: str, pkg_name: str) -> str | None:
     # it returns full path, in others just a filename. It still may be worth
     # it as a fallback even in the filename-only case, to help troubleshoot some
     # yet unknown source
-    return ctypes.util.find_library(lib_name)
+    return (ctypes.util.find_library(lib_name) or
+            ctypes.util.find_library(lib_name.removeprefix('lib')))
 
 
 def find(lib_name: str, pkg_name: str | None = None) -> str | None:


### PR DESCRIPTION
In 0.0.5 the ctypes.util.find_library fallback searched for lib_name without the "lib" prefix.

Using the prefix breaks the fallback on some platforms: Ubuntu 16.04, 20.04, 22.04. Fix this by trying both name conventions