### PR TITLE
Make CDLL load globally

### DIFF
--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -36,12 +36,14 @@ EXTENSIONS_RE = defaultdict(
     win32=r"^.*\.dll$",
 )
 
+
 def _load_globally(path: str) -> CDLL:
     """Loads the library to make it accessible to subsequently loaded libraries and extensions"""
     # NOTE this doesnt ultimately work on MacOS -- without corresponding `rpath`s on the lib, we end up
     # failing asserts in `eckit::system::LibraryRegistry::enregister`. Possibly, fixing that assert,
     # making library names correct, etc, could make this work
     return CDLL(path, mode=RTLD_GLOBAL)
+
 
 def _single_preload_deps(path: str) -> None:
     """See _find_in_package"""
@@ -298,6 +300,7 @@ def find(lib_name: str, pkg_name: str | None = None) -> str | None:
             logger.debug(f"found {lib_name}/{pkg_name} in {source}")
             return result
     return None
+
 
 def load(lib_name: str, pkg_name: str | None = None) -> CDLL:
     """Convenience method to find a library and load it right away (recursively)"""

--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -17,7 +17,7 @@ import re
 import sys
 import warnings
 from collections import defaultdict
-from ctypes import CDLL
+from ctypes import CDLL, RTLD_GLOBAL
 from pathlib import Path
 from types import ModuleType
 
@@ -36,6 +36,12 @@ EXTENSIONS_RE = defaultdict(
     win32=r"^.*\.dll$",
 )
 
+def _load_globally(path: str) -> CDLL:
+    """Loads the library to make it accessible to subsequently loaded libraries and extensions"""
+    # NOTE this doesnt ultimately work on MacOS -- without corresponding `rpath`s on the lib, we end up
+    # failing asserts in `eckit::system::LibraryRegistry::enregister`. Possibly, fixing that assert,
+    # making library names correct, etc, could make this work
+    return CDLL(path, mode=RTLD_GLOBAL)
 
 def _single_preload_deps(path: str) -> None:
     """See _find_in_package"""
@@ -44,7 +50,7 @@ def _single_preload_deps(path: str) -> None:
         logger.debug(f"considering {lib}")
         if re.match(EXTENSIONS_RE[sys.platform], lib):
             logger.debug(f"loading {lib} at {path}")
-            _ = CDLL(f"{path}/{lib}")
+            _ = _load_globally(f"{path}/{lib}")
             logger.debug(f"loaded {lib}")
 
 
@@ -89,7 +95,7 @@ def _find_in_package(
     if preload_deps is None:
         preload_deps = (
             sys.platform != "darwin"
-        )  # NOTE dyld doesnt seem to coop with ctypes.CDLL of weak-deps
+        )  # NOTE see _load_globally for explanation
     try:
         module = importlib.import_module(pkg_name)
         logger.debug(f"found package {pkg_name}; with {preload_deps=}")
@@ -292,3 +298,11 @@ def find(lib_name: str, pkg_name: str | None = None) -> str | None:
             logger.debug(f"found {lib_name}/{pkg_name} in {source}")
             return result
     return None
+
+def load(lib_name: str, pkg_name: str | None = None) -> CDLL:
+    """Convenience method to find a library and load it right away (recursively)"""
+    path = find(lib_name, pkg_name)
+    if not path:
+        raise ValueError(f"unable to find {pkg_name+'.' if pkg_name else ''}{lib_name}")
+    else:
+        return _load_globally(path)

--- a/tests/transitive/test_transitive.py
+++ b/tests/transitive/test_transitive.py
@@ -1,6 +1,6 @@
 import sys
-from pathlib import Path
 import typing
+from pathlib import Path
 
 import findlibs
 

--- a/tests/transitive/test_transitive.py
+++ b/tests/transitive/test_transitive.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import typing
 
 import findlibs
 
@@ -18,7 +19,7 @@ def test_transitive(monkeypatch) -> None:
     # the files in test are not real .so, we thus just track what got loaded
     loaded_libs = set()
 
-    def libload_accumulator(path: str):
+    def libload_accumulator(path: str, mode: typing.Any):
         loaded_libs.add(path)
 
     monkeypatch.setattr(findlibs, "CDLL", libload_accumulator)


### PR DESCRIPTION
There is a difference on MacOS between just `CDLL(path)` and `CDLL(path, mode=RTLD_GLOBAL)`, when it comes to making the symbols from the library accessible to subsequent CDLL load calls. This doesn't yet eliminate the need for hardcoding `LC_RPATH`, as we probably have something wrong on the library naming level, but gets us one step closer.

Additionally I add a convenience `load` function, since most of the `findlibs.find` is followed by a load anyway -- we will need to change all `*-python` libraries to utilize this prior to removing the `LC_RPATH` hardcoding, if we ever fix that


I tested on my MacOS & ubuntu docker, with `findlibs.load("mir")` still working without crash, but haven't done anything more involved. Didn't ideate how to extend pytests to cover this as we parametrize `CDLL` which is fully mocked and very OS-specific. The original usage of `findlibs`, ie, not using the wheel chains, should not be affected at all.