### PR TITLE
Python 3.9 eol prep

### DIFF
--- a/findlibs/__init__.py
+++ b/findlibs/__init__.py
@@ -294,7 +294,7 @@ def find(lib_name: str, pkg_name: Union[str, None] = None) -> Union[str, None]:
     sources_filtered = (
         source_clb
         for source_clb, source_name in sources
-        if os.environ.get(f"FINDLIBS_DISABLE_{source_name}", None) != "yes"
+        if os.environ.get(f"FINDLIBS_DISABLE_{source_name}", None) not in ("yes", "1")
     )
 
     for source in sources_filtered:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,13 @@ license = { text = "Apache License Version 2.0" }
 authors = [
   { name = "European Centre for Medium-Range Weather Forecasts (ECMWF)", email = "software@ecmwf.int" }
 ]
+requires-python = ">=3.10"
 keywords = ["tool"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Setting classifiers and python-requires correctly -- 3.9 is out soon, and we actually aren't compatible due to annotations usage

Fixes https://github.com/ecmwf/findlibs/issues/18